### PR TITLE
fix(turn): prevent spurious permission denials during churn and cut relay noise

### DIFF
--- a/openvidu/customrouting/redis.go
+++ b/openvidu/customrouting/redis.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
+	"github.com/livekit/protocol/logger"
+
 	"github.com/livekit/livekit-server/pkg/config"
 )
 
@@ -61,6 +63,20 @@ func RegisterNodeCustom(ctx context.Context, rc redis.UniversalClient, nodeId st
 		return nil
 	}
 
+	return registerNode(ctx, rc, nodeId, nodeIP, globalConfig.ResolvedRelayAddress)
+}
+
+// registerNode registers nodeId in the nodes_openvidu hash, replacing any stale
+// entries that advertise the same nodeIP.
+//
+// The removal of stale entries (HDEL) and the insertion of the new entry (HSET)
+// are performed together in a single MULTI/EXEC transaction. This guarantees a
+// concurrent reader (notably the TURN permission check, which does an HGETALL of
+// this hash) can never observe a transient window where the IP is absent from
+// the hash. Done as two separate commands, recycling a node's IP would briefly
+// drop it from the allow set and cause spurious "peer IP not in cluster nodes"
+// TURN denials for that IP.
+func registerNode(ctx context.Context, rc redis.UniversalClient, nodeId, nodeIP, relayAddress string) error {
 	exist, err := rc.HExists(ctx, NodesOpenViduKey, nodeId).Result()
 	if err != nil {
 		return fmt.Errorf("failed to check if node is registered: %w", err)
@@ -74,30 +90,28 @@ func RegisterNodeCustom(ctx context.Context, rc redis.UniversalClient, nodeId st
 		return fmt.Errorf("failed to get all nodes: %w", err)
 	}
 
-	// collect IDs of old nodes to remove them
+	// collect IDs of stale nodes advertising the same IP so they can be replaced
+	// atomically together with this node's registration
 	var nodeIDsToRemove []string
 	for _, rawNode := range rawNodes {
 		var ovNode NodeOpenVidu
-		err := json.Unmarshal([]byte(rawNode), &ovNode)
-		if err != nil {
-			return fmt.Errorf("failed to unmarshal node: %w", err)
+		if err := json.Unmarshal([]byte(rawNode), &ovNode); err != nil {
+			// A single malformed sibling entry must not block this node from
+			// registering — that would leave it absent from nodes_openvidu and
+			// cause spurious TURN denials. Skip it, mirroring the reader's
+			// tolerance (fetchAllowedIPs in the TURN permission check).
+			logger.Warnw("skipping malformed node entry during registration", err, "raw", rawNode)
+			continue
 		}
 		if ovNode.NodeIp == nodeIP && ovNode.NodeId != nodeId {
 			nodeIDsToRemove = append(nodeIDsToRemove, ovNode.NodeId)
 		}
 	}
 
-	// remove old nodes if any exist
-	if len(nodeIDsToRemove) > 0 {
-		if err := rc.HDel(ctx, NodesOpenViduKey, nodeIDsToRemove...).Err(); err != nil {
-			return fmt.Errorf("failed to delete nodes: %w", err)
-		}
-	}
-
 	ovNode := NodeOpenVidu{
 		NodeId:       nodeId,
 		NodeIp:       nodeIP,
-		RelayAddress: globalConfig.ResolvedRelayAddress,
+		RelayAddress: relayAddress,
 	}
 
 	jsonOvNode, err := json.Marshal(ovNode)
@@ -105,8 +119,15 @@ func RegisterNodeCustom(ctx context.Context, rc redis.UniversalClient, nodeId st
 		return fmt.Errorf("failed to marshal node: %w", err)
 	}
 
-	if err := rc.HSet(ctx, NodesOpenViduKey, nodeId, jsonOvNode).Err(); err != nil {
-		return fmt.Errorf("failed to set node: %w", err)
+	// Atomic replace: HDEL stale entries + HSET this node in one transaction so
+	// the IP is never transiently missing from nodes_openvidu.
+	pipe := rc.TxPipeline()
+	if len(nodeIDsToRemove) > 0 {
+		pipe.HDel(ctx, NodesOpenViduKey, nodeIDsToRemove...)
+	}
+	pipe.HSet(ctx, NodesOpenViduKey, nodeId, jsonOvNode)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("failed to register node: %w", err)
 	}
 
 	return nil

--- a/openvidu/customrouting/redis_test.go
+++ b/openvidu/customrouting/redis_test.go
@@ -1,0 +1,139 @@
+// Copyright 2024 OpenVidu
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package customrouting
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRedis(t *testing.T) (*miniredis.Miniredis, redis.UniversalClient) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	return mr, rc
+}
+
+func seedNode(t *testing.T, mr *miniredis.Miniredis, nodeID, nodeIP, relayAddr string) {
+	t.Helper()
+	b, err := json.Marshal(NodeOpenVidu{NodeId: nodeID, NodeIp: nodeIP, RelayAddress: relayAddr})
+	require.NoError(t, err)
+	mr.HSet(NodesOpenViduKey, nodeID, string(b))
+}
+
+func readNodes(t *testing.T, rc redis.UniversalClient) map[string]NodeOpenVidu {
+	t.Helper()
+	raw, err := rc.HGetAll(context.Background(), NodesOpenViduKey).Result()
+	require.NoError(t, err)
+	out := make(map[string]NodeOpenVidu, len(raw))
+	for id, v := range raw {
+		var n NodeOpenVidu
+		require.NoError(t, json.Unmarshal([]byte(v), &n))
+		out[id] = n
+	}
+	return out
+}
+
+// A fresh node with no stale entries is simply registered.
+func TestRegisterNode_AddsWhenNoStale(t *testing.T) {
+	_, rc := newTestRedis(t)
+
+	require.NoError(t, registerNode(context.Background(), rc, "node-1", "10.0.0.1", "10.0.0.1"))
+
+	nodes := readNodes(t, rc)
+	require.Len(t, nodes, 1)
+	require.Equal(t, NodeOpenVidu{NodeId: "node-1", NodeIp: "10.0.0.1", RelayAddress: "10.0.0.1"}, nodes["node-1"])
+}
+
+// A stale entry advertising the same IP is replaced (HDEL+HSET) atomically; the
+// end state has exactly the new node and never both/neither.
+func TestRegisterNode_ReplacesStaleSameIP(t *testing.T) {
+	mr, rc := newTestRedis(t)
+	seedNode(t, mr, "node-old", "10.0.0.1", "10.0.0.1")
+
+	require.NoError(t, registerNode(context.Background(), rc, "node-new", "10.0.0.1", "10.0.0.1"))
+
+	nodes := readNodes(t, rc)
+	require.Len(t, nodes, 1, "stale same-IP entry must be removed")
+	require.Contains(t, nodes, "node-new")
+	require.NotContains(t, nodes, "node-old")
+	require.Equal(t, "10.0.0.1", nodes["node-new"].NodeIp)
+}
+
+// Nodes with a different IP are left untouched — only same-IP staleness is
+// reconciled.
+func TestRegisterNode_KeepsDifferentIPNodes(t *testing.T) {
+	mr, rc := newTestRedis(t)
+	seedNode(t, mr, "node-a", "10.0.0.9", "10.0.0.9")
+
+	require.NoError(t, registerNode(context.Background(), rc, "node-b", "10.0.0.1", "10.0.0.1"))
+
+	nodes := readNodes(t, rc)
+	require.Len(t, nodes, 2)
+	require.Contains(t, nodes, "node-a")
+	require.Contains(t, nodes, "node-b")
+}
+
+// If the node id is already registered, registration is a no-op and the stored
+// entry is not overwritten (HEXISTS short-circuit).
+func TestRegisterNode_NoopWhenAlreadyRegistered(t *testing.T) {
+	mr, rc := newTestRedis(t)
+	seedNode(t, mr, "node-1", "10.0.0.1", "10.0.0.1")
+
+	require.NoError(t, registerNode(context.Background(), rc, "node-1", "10.0.0.99", "10.0.0.99"))
+
+	nodes := readNodes(t, rc)
+	require.Len(t, nodes, 1)
+	require.Equal(t, "10.0.0.1", nodes["node-1"].NodeIp, "existing entry must not be overwritten")
+}
+
+// Registering replaces every stale entry that shares the IP, not just one.
+func TestRegisterNode_ReplacesMultipleStaleSameIP(t *testing.T) {
+	mr, rc := newTestRedis(t)
+	seedNode(t, mr, "node-old-1", "10.0.0.1", "10.0.0.1")
+	seedNode(t, mr, "node-old-2", "10.0.0.1", "10.0.0.1")
+	seedNode(t, mr, "keep", "10.0.0.2", "10.0.0.2")
+
+	require.NoError(t, registerNode(context.Background(), rc, "node-new", "10.0.0.1", "10.0.0.1"))
+
+	nodes := readNodes(t, rc)
+	require.Len(t, nodes, 2)
+	require.Contains(t, nodes, "node-new")
+	require.Contains(t, nodes, "keep")
+	require.NotContains(t, nodes, "node-old-1")
+	require.NotContains(t, nodes, "node-old-2")
+}
+
+// A malformed sibling entry must not block a healthy node from registering —
+// otherwise that node stays absent from nodes_openvidu and gets spurious TURN
+// denials. The corrupt entry is skipped; the registration still succeeds.
+func TestRegisterNode_SkipsMalformedSibling(t *testing.T) {
+	mr, rc := newTestRedis(t)
+	mr.HSet(NodesOpenViduKey, "corrupt", "{ not valid json")
+	seedNode(t, mr, "node-old", "10.0.0.1", "10.0.0.1")
+
+	require.NoError(t, registerNode(context.Background(), rc, "node-new", "10.0.0.1", "10.0.0.1"))
+
+	raw, err := rc.HGetAll(context.Background(), NodesOpenViduKey).Result()
+	require.NoError(t, err)
+	require.Contains(t, raw, "node-new", "healthy node must register despite a corrupt sibling")
+	require.NotContains(t, raw, "node-old", "stale same-IP entry is still replaced")
+}

--- a/pkg/service/turn_security.go
+++ b/pkg/service/turn_security.go
@@ -39,6 +39,14 @@ import (
 // regardless of TTL, so new nodes are visible instantly.
 const defaultTURNCacheTTL = time.Minute
 
+// negativeRevalidateInterval bounds how often a "miss" against a freshly
+// refreshed snapshot is revalidated with another Redis fetch. A newer snapshot
+// that does not contain the peer IP is revalidated (it might be a transient gap
+// in nodes_openvidu), but only once it is at least this old — so a burst of
+// concurrent misses for the same genuinely-absent IP reuses the snapshot instead
+// of each issuing its own fetch, preventing a fetch storm.
+const negativeRevalidateInterval = 100 * time.Millisecond
+
 // TURNSecurity restricts TURN relay connections so that only peer IPs
 // belonging to registered cluster nodes or the local machine are allowed.
 //
@@ -199,7 +207,7 @@ func (s *TURNSecurity) handlePermission(_ net.Addr, peerIP net.IP) bool {
 	}
 
 	// Cache miss or expired: refresh from Redis.
-	allowed, err := s.refreshCache(cacheTime)
+	allowed, err := s.refreshCache(cacheTime, peerStr)
 	if err != nil {
 		logger.Warnw("TURN permission denied: failed to query cluster nodes from Redis", err, "peerIP", peerStr)
 		return false
@@ -207,21 +215,57 @@ func (s *TURNSecurity) handlePermission(_ net.Addr, peerIP net.IP) bool {
 
 	_, ok := allowed[peerStr]
 	if !ok {
-		logger.Infow("TURN permission denied: peer IP not in cluster nodes", "peerIP", peerStr)
+		if isPublicIP(peerIP) {
+			// A relay attempt toward a non-cluster PUBLIC IP is a genuine security
+			// signal: the embedded relay must not act as an open proxy. Surface it.
+			logger.Warnw("TURN permission denied: peer IP not in cluster nodes", nil, "peerIP", peerStr)
+		} else {
+			// A private/link-local peer IP is almost always a cluster node that is
+			// transiently absent from nodes_openvidu during churn (benign). Keep it
+			// at info to avoid warning-level noise.
+			logger.Infow("TURN permission denied: peer IP not in cluster nodes", "peerIP", peerStr)
+		}
 	}
 	return ok
 }
 
+// isPublicIP reports whether ip is a globally-routable address (not private,
+// loopback, link-local or unspecified). Used to decide whether a denied relay
+// peer is a genuine external target (worth a warning) or a benign in-cluster
+// address transiently missing from nodes_openvidu.
+func isPublicIP(ip net.IP) bool {
+	return ip != nil &&
+		ip.IsGlobalUnicast() &&
+		!ip.IsPrivate() &&
+		!ip.IsLinkLocalUnicast()
+}
+
 // refreshCache fetches the allowed IPs from Redis and updates the cache.
-// prevCacheTime is used to deduplicate concurrent refreshes: if another
-// goroutine already refreshed after prevCacheTime, its result is reused.
-func (s *TURNSecurity) refreshCache(prevCacheTime time.Time) (map[string]struct{}, error) {
+// prevCacheTime deduplicates concurrent refreshes, but only for a POSITIVE
+// result: if another goroutine already refreshed after prevCacheTime and the
+// requested peerStr is present in that snapshot, it is reused. If peerStr is
+// absent, the newer snapshot may have been captured during a transient
+// inconsistency in nodes_openvidu (e.g. the brief window while a node IP is
+// recycled), so we fall through to a fresh fetch rather than deny based on an
+// unvalidated snapshot — but that negative revalidation is rate-limited by
+// negativeRevalidateInterval so a burst of misses for the same absent IP cannot
+// cause a fetch storm.
+func (s *TURNSecurity) refreshCache(prevCacheTime time.Time, peerStr string) (map[string]struct{}, error) {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
 
 	// Another goroutine may have refreshed while we waited for the lock.
 	if s.cacheTime.After(prevCacheTime) {
-		return s.cachedIPs, nil
+		// Positive result: a newer snapshot confirms the IP — reuse it.
+		if _, ok := s.cachedIPs[peerStr]; ok {
+			return s.cachedIPs, nil
+		}
+		// Negative result: revalidate with a fresh fetch only if the snapshot is
+		// old enough that Redis may have changed; otherwise reuse it to bound
+		// refetch load under a burst of misses for the same absent IP.
+		if time.Since(s.cacheTime) < negativeRevalidateInterval {
+			return s.cachedIPs, nil
+		}
 	}
 
 	allowed, err := s.fetchAllowedIPs()
@@ -292,9 +336,14 @@ func (c *openviduRelayPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) 
 		return 0, err
 	}
 	if port < c.minPort || port > c.maxPort {
-		portErr := fmt.Errorf("destination port %d outside allowed range [%d, %d]", port, c.minPort, c.maxPort)
-		logger.Warnw("Permission denied: destination port outside allowed range", portErr, "destAddr", addr.String(), "port", port, "minPort", c.minPort, "maxPort", c.maxPort)
-		return 0, portErr
+		// Expected and high-volume: ICE probes reflexive/relay candidates on
+		// ephemeral ports outside the media range — mostly the cluster nodes' own
+		// srflx candidates (public IP : NAT-mapped port) for intra-cluster links —
+		// which the relay declines. Logged at debug to avoid flooding warnings; the
+		// relay still refuses the write and returns the error to the caller.
+		logger.Debugw("relay destination port outside allowed range, dropping packet",
+			"destAddr", addr.String(), "port", port, "minPort", c.minPort, "maxPort", c.maxPort)
+		return 0, fmt.Errorf("destination port %d outside allowed range [%d, %d]", port, c.minPort, c.maxPort)
 	}
 
 	n, err := c.PacketConn.WriteTo(p, addr)

--- a/pkg/service/turn_security_test.go
+++ b/pkg/service/turn_security_test.go
@@ -1372,4 +1372,131 @@ func TestTURNSecurity_AllowCIDR_IPv6Grant(t *testing.T) {
 	require.False(t, checkPermission(h, "2001:dead::1"), "unlisted public IPv6 peer denied")
 }
 
+// ---------------------------------------------------------------------------
+// Refresh dedup: a newer snapshot is only trusted for a positive result
+// ---------------------------------------------------------------------------
+
+func TestTURNSecurity_Redis_RefreshRevalidatesNegativeDedup(t *testing.T) {
+	// Simulate a poisoned snapshot: the cache is fresh but missing an IP that is
+	// actually present in Redis (as if captured during a transient gap). A
+	// concurrent refresh for that IP must NOT trust the newer snapshot; it must
+	// refetch from Redis and find the IP.
+	mr, rc := newMiniredis(t)
+	setNode(t, mr, "node-1", "10.0.0.1", "10.0.0.1")
+
+	s := NewTURNSecurity(&config.Config{}, rc)
+
+	s.cacheMu.Lock()
+	s.cachedIPs = map[string]struct{}{"10.0.0.2": {}} // poisoned: missing 10.0.0.1
+	s.cacheTime = time.Now().Add(-time.Second)        // older than negativeRevalidateInterval
+	s.cacheMu.Unlock()
+
+	// prevCacheTime in the past → the dedup short-circuit would otherwise fire;
+	// the snapshot is older than negativeRevalidateInterval so it is revalidated.
+	allowed, err := s.refreshCache(time.Time{}, "10.0.0.1")
+	require.NoError(t, err)
+	_, ok := allowed["10.0.0.1"]
+	require.True(t, ok, "negative dedup must refetch and find the present IP")
+}
+
+func TestTURNSecurity_Redis_PositiveDedupSkipsRefetch(t *testing.T) {
+	// When the newer snapshot already confirms the IP, the dedup short-circuit
+	// is used and no Redis fetch happens — proven by breaking Redis and still
+	// getting a positive result without error.
+	mr, rc := newMiniredis(t)
+	setNode(t, mr, "node-1", "10.0.0.1", "10.0.0.1")
+
+	s := NewTURNSecurity(&config.Config{}, rc)
+
+	s.cacheMu.Lock()
+	s.cachedIPs = map[string]struct{}{"10.0.0.1": {}}
+	s.cacheTime = time.Now()
+	s.cacheMu.Unlock()
+
+	mr.SetError("LOADING Redis is loading the dataset in memory")
+
+	allowed, err := s.refreshCache(time.Time{}, "10.0.0.1")
+	require.NoError(t, err, "positive dedup must not hit Redis")
+	_, ok := allowed["10.0.0.1"]
+	require.True(t, ok)
+}
+
+func TestTURNSecurity_Redis_RefreshNegativeDedupStillDeniesAbsentIP(t *testing.T) {
+	// Revalidating a negative dedup must not falsely allow: if the IP is also
+	// genuinely absent from Redis, the refetched snapshot is negative and the IP
+	// stays denied. (Guards against the fix turning every miss into an allow.)
+	mr, rc := newMiniredis(t)
+	setNode(t, mr, "node-1", "10.0.0.1", "10.0.0.1")
+
+	s := NewTURNSecurity(&config.Config{}, rc)
+
+	s.cacheMu.Lock()
+	s.cachedIPs = map[string]struct{}{"10.0.0.1": {}}
+	s.cacheTime = time.Now().Add(-time.Second) // older than negativeRevalidateInterval → revalidates
+	s.cacheMu.Unlock()
+
+	allowed, err := s.refreshCache(time.Time{}, "9.9.9.9")
+	require.NoError(t, err)
+	_, ok := allowed["9.9.9.9"]
+	require.False(t, ok, "genuinely absent IP must stay denied after revalidation")
+	// The revalidating refetch also reconciled the cache with real Redis state.
+	_, ok = allowed["10.0.0.1"]
+	require.True(t, ok)
+}
+
+func TestTURNSecurity_Redis_NegativeDedupRateLimitedWhenFresh(t *testing.T) {
+	// A negative result against a very fresh snapshot is reused (not refetched),
+	// bounding refetch load under a burst of misses for a genuinely-absent IP.
+	mr, rc := newMiniredis(t)
+	setNode(t, mr, "node-1", "10.0.0.1", "10.0.0.1")
+
+	s := NewTURNSecurity(&config.Config{}, rc)
+
+	fresh := time.Now()
+	s.cacheMu.Lock()
+	s.cachedIPs = map[string]struct{}{"10.0.0.1": {}}
+	s.cacheTime = fresh
+	s.cacheMu.Unlock()
+
+	allowed, err := s.refreshCache(time.Time{}, "9.9.9.9")
+	require.NoError(t, err)
+	_, ok := allowed["9.9.9.9"]
+	require.False(t, ok)
+
+	// No refetch happened within the interval: the snapshot/time are untouched.
+	s.cacheMu.RLock()
+	require.Equal(t, fresh, s.cacheTime, "fresh negative snapshot must be reused, not refetched")
+	s.cacheMu.RUnlock()
+}
+
+// ---------------------------------------------------------------------------
+// Denied-peer severity classification
+// ---------------------------------------------------------------------------
+
+func TestTURNSecurity_IsPublicIP(t *testing.T) {
+	// Public/global addresses (a denied relay peer here is a genuine external
+	// target → warning); private/local addresses (a benign in-cluster address
+	// transiently missing from nodes_openvidu → info).
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"3.252.97.62", true},    // public (AWS)
+		{"108.131.122.27", true}, // public
+		{"2001:db8::1", true},    // global unicast IPv6
+		{"10.0.0.1", false},      // private
+		{"10.10.14.163", false},  // private (cluster node)
+		{"172.16.5.4", false},    // private
+		{"192.168.1.1", false},   // private
+		{"127.0.0.1", false},     // loopback
+		{"169.254.1.1", false},   // link-local
+		{"fe80::1", false},       // link-local IPv6
+		{"fd00::1", false},       // unique-local IPv6 (private)
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, isPublicIP(net.ParseIP(c.ip)), "ip=%s", c.ip)
+	}
+	require.False(t, isPublicIP(nil))
+}
+
 // END OPENVIDU BLOCK


### PR DESCRIPTION
## Problem

On busy HA clusters, two TURN-related issues show up during node churn:

1. **Spurious relay-peer denials.** Live media nodes are occasionally denied as TURN relay peers with `TURN permission denied: peer IP not in cluster nodes`, in short sub-second bursts that coincide with node (un)registration. The node is up the whole time; its IP is only *transiently* absent from the `nodes_openvidu` Redis hash.
2. **High-volume benign warnings.** The embedded relay logs `Permission denied: destination port outside allowed range` at high volume (hundreds/day) — these are ICE connectivity checks to reflexive candidates on ephemeral ports (mostly the cluster nodes' own srflx candidates), which the relay correctly declines.

## Root cause

- `RegisterNodeCustom` removed stale same-IP entries and inserted the new one as **two separate Redis commands** (`HDEL` then `HSET`). When a node IP is recycled, a concurrent `HGETALL` from the TURN permission check can land in the gap and see the IP missing.
- The permission cache's dedup short-circuit trusted a newer concurrent snapshot **even for a negative result**, so a snapshot captured during that gap could be served (and amplified across concurrent checks) instead of being revalidated.
- A single malformed entry in `nodes_openvidu` aborted `RegisterNodeCustom` entirely, which could keep healthy nodes out of the allowlist.

## Changes

**`openvidu/customrouting/redis.go`**
- Registration is now **atomic**: `HDEL` (stale same-IP) + `HSET` (self) run in a single `MULTI`/`EXEC` transaction, so the IP is never transiently missing from the hash.
- A malformed sibling entry is **skipped (log + continue)** instead of failing the registration, mirroring the reader's tolerance.

**`pkg/service/turn_security.go`**
- `refreshCache` only trusts a newer concurrent snapshot for a **positive** result; a negative result is **revalidated with a fresh fetch** rather than denying on a possibly-stale snapshot. Negative revalidation is **rate-limited** (`negativeRevalidateInterval`) to avoid a fetch storm for genuinely-absent IPs.
- The relay destination-port denial is demoted to **debug** (benign, high-volume; behaviour unchanged — the relay still refuses the write).
- The peer-IP denial is classified by address: **warn** for a public/external IP (a genuine open-relay attempt), **info** for a private/cluster address (a node transiently missing during churn).

## Tests

`miniredis`-backed unit tests covering:
- Atomic registration, stale same-IP replacement, and tolerance of a malformed sibling.
- Positive vs negative dedup (revalidation, still-denies-when-absent, rate-limit reuse).
- `isPublicIP` classification.

All `pkg/service` and `openvidu/customrouting` tests pass, including `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
